### PR TITLE
[Fix] 무기 해제시 델리게이트를 불러 오류 해결

### DIFF
--- a/ProjectFA/Source/ProjectFA/FACharacter/Player/PlayableCharacterCombatComponent.cpp
+++ b/ProjectFA/Source/ProjectFA/FACharacter/Player/PlayableCharacterCombatComponent.cpp
@@ -39,6 +39,12 @@ void UPlayableCharacterCombatComponent::EquipItemToCharacter(APickupItem* ItemTo
 	{
 		RightHandSocket->AttachActor(EquippedItem, Character->GetMesh());
 	}
+	if(const auto Equipable = Cast<IEquipable>(ItemToEquip))
+	{
+		FEquipItemEvent Event;
+		Event.AddDynamic(this, &UPlayableCharacterCombatComponent::ItemDrop);
+		Equipable->SetUnEquipEvent(Event);
+	}
 }
 
 void UPlayableCharacterCombatComponent::Attack()
@@ -71,5 +77,13 @@ void UPlayableCharacterCombatComponent::SetWeaponAttackCollision(bool bEnabled)
 	if(auto const WeaponInterface = Cast<IEquipable>(EquippedItem))
 	{
 		WeaponInterface->SetAttackCollision(bEnabled);
+	}
+}
+
+void UPlayableCharacterCombatComponent::ItemDrop(APickupItem* UnEquipItem)
+{
+	if(UnEquipItem == EquippedItem)
+	{
+		EquippedItem = nullptr;
 	}
 }

--- a/ProjectFA/Source/ProjectFA/FACharacter/Player/PlayableCharacterCombatComponent.h
+++ b/ProjectFA/Source/ProjectFA/FACharacter/Player/PlayableCharacterCombatComponent.h
@@ -49,4 +49,9 @@ public:
 protected:
 	
 	virtual void BeginPlay() override;
+
+private:
+	
+	UFUNCTION()
+	void ItemDrop(APickupItem* UnEquipItem);
 };

--- a/ProjectFA/Source/ProjectFA/InGameItem/Equipable.h
+++ b/ProjectFA/Source/ProjectFA/InGameItem/Equipable.h
@@ -30,4 +30,5 @@ public:
 	virtual void UnEquip() = 0;
 	virtual void SetAttackCollision(bool bEnable) = 0;
 	virtual void SetEquipItemEvent(const FEquipItemEvent& Event) = 0;
+	virtual void SetUnEquipEvent(const FEquipItemEvent& Event) = 0;
 };

--- a/ProjectFA/Source/ProjectFA/InGameItem/Weapon/Weapon.cpp
+++ b/ProjectFA/Source/ProjectFA/InGameItem/Weapon/Weapon.cpp
@@ -50,6 +50,7 @@ void AWeapon::UnEquip()
 	const FDetachmentTransformRules DetachRules{ EDetachmentRule::KeepWorld, true };
 	PickupItemMesh->DetachFromComponent(DetachRules);
 	SetItemState(EItemState::EIS_InInventory);
+	UnEquipEvent.Broadcast(this);
 }
 
 void AWeapon::SetAttackCollision(bool bEnable)
@@ -63,6 +64,11 @@ void AWeapon::SetEquipItemEvent(const FEquipItemEvent& Event)
 {
 	EquipItemEvent.Clear();
 	EquipItemEvent = Event;
+}
+
+void AWeapon::SetUnEquipEvent(const FEquipItemEvent& Event)
+{
+	UnEquipEvent = Event;	
 }
 
 void AWeapon::InventoryAction_Implementation()

--- a/ProjectFA/Source/ProjectFA/InGameItem/Weapon/Weapon.h
+++ b/ProjectFA/Source/ProjectFA/InGameItem/Weapon/Weapon.h
@@ -32,6 +32,7 @@ class PROJECTFA_API AWeapon : public APickupItem, public IEquipable, public IInv
 public:
 
 	FEquipItemEvent EquipItemEvent;
+	FEquipItemEvent UnEquipEvent;
 
 private:
 	
@@ -50,6 +51,7 @@ public:
 	virtual void UnEquip() override;
 	virtual void SetAttackCollision(bool bEnable) override;
 	virtual void SetEquipItemEvent(const FEquipItemEvent& Event) override;
+	virtual void SetUnEquipEvent(const FEquipItemEvent& Event) override;
 
 	virtual void InventoryAction_Implementation() override;
 	virtual void RemoveFromInventoryAction_Implementation() override;


### PR DESCRIPTION
https://github.com/HUSK-321/FantasyApocalypse/issues/22

델리게이트를 추가 해 장착시 해제하는 로직을 추가해 오류를 해결했습니다.